### PR TITLE
New package: VSCodium 1.63.2

### DIFF
--- a/srcpkgs/vscodium/REMOVE
+++ b/srcpkgs/vscodium/REMOVE
@@ -1,0 +1,9 @@
+if [ "$UPDATE" = "no" ]; then
+    case "$ACTION" in
+        post)
+            if [ -d usr/lib/vscodium ]; then
+                rm -rf usr/lib/vscodium
+            fi
+        ;;
+    esac
+fi

--- a/srcpkgs/vscodium/files/vscodium.desktop
+++ b/srcpkgs/vscodium/files/vscodium.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Name=VSCodium
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec=/usr/lib/vscodium/codium --unity-launch %F
+Icon=vscodium
+Type=Application
+StartupNotify=true
+StartupWMClass=VSCodium
+Categories=Utility;Development;IDE;
+MimeType=text/plain;inode/directory;
+Actions=new-empty-window;
+Keywords=vscode;
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Exec=/usr/lib/vscodium/codium --new-window %F
+Icon=vscodium

--- a/srcpkgs/vscodium/template
+++ b/srcpkgs/vscodium/template
@@ -1,0 +1,37 @@
+# Template file for 'vscodium'
+pkgname=vscodium
+version=1.63.2
+revision=1
+#archs="x86_64"
+#wrksrc=
+create_wrksrc=yes
+#build_style=gnu-configure
+#configure_args=""
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends=""
+makedepends=""
+depends="libXtst libxkbfile nss dejavu-fonts-ttf"
+short_desc="Binary releases of VS Code without MS branding/telemetry/licensing "
+maintainer="Khiem Ton That <10154337-th4tkh13m@users.noreply.gitlab.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/VSCodium/vscodium"
+distfiles="https://github.com/VSCodium/vscodium/releases/download/${version}/VSCodium-linux-x64-${version}.tar.gz"
+checksum=a04b7d8b5da747f76dc8d0785b5948424d90e6320cc5704601a93ee9e2ca9f5d
+do_install() {
+	vmkdir usr/lib/vscodium
+	vcopy * usr/lib/vscodium
+
+	vmkdir usr/bin
+	ln -sf /usr/lib/vscodium/bin/codium ${DESTDIR}/usr/bin/
+
+	vmkdir usr/share/applications
+	vcopy ${FILESDIR}/vscodium.desktop usr/share/applications/
+
+	vmkdir usr/share/pixmaps
+	ln -sf /usr/lib/vscodium/resources/app/resources/linux/code.png ${DESTDIR}/usr/share/pixmaps/vscodium.png
+
+	vlicense resources/app/LICENSE.txt
+}


### PR DESCRIPTION
Add VSCodium, a modified version of VS Code without MS branding/telemetry/licensing